### PR TITLE
fix: place the using_library statement before the types importation

### DIFF
--- a/depth_map_preprocessing.orogen
+++ b/depth_map_preprocessing.orogen
@@ -1,10 +1,10 @@
 name "depth_map_preprocessing"
 version "0.1"
 
+using_library "depth_map_preprocessing"
+
 import_types_from "base"
 import_types_from "depth_map_preprocessing/Config.hpp"
-
-using_library "depth_map_preprocessing"
 
 # This filter has the goal to remove separated measurements in the scan
 # and support measurements with neighboring measurements.


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
Fix the depth map preprocessing interface placing the using_library statement before the types importation
The old order was causing the following error in the build process:

![image](https://github.com/rock-perception/perception-orogen-depth_map_preprocessing/assets/80434858/64c46f06-57c2-4c01-870f-92a657c507bb)

# Checklist
- [x] Assign yourself  in the PR
